### PR TITLE
Add CritToken struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `interrupt::CritToken`, a struct that only exists in a critical section.
+
+### Changed
+
+- The closure that `interrupt::free` takes now takes a reference to an `interrupt::CritToken`.
+
 ## [v0.1.5]
 
 ### Added

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -22,12 +22,21 @@ impl<T> Mutex<T> {
     pub fn lock<F, R>(&self, f: F) -> R
         where F: FnOnce(&mut T) -> R
     {
-        unsafe { ::interrupt::free(|| f(&mut *self.inner.get())) }
+        unsafe { ::interrupt::free(|_| f(&mut *self.inner.get())) }
     }
 }
 
 // FIXME `T` should have some bound: `Send` or `Sync`?
 unsafe impl<T> Sync for Mutex<T> {}
+
+/// A struct whos existence guarantees that interrupts are disabled
+///
+/// This struct is zero-sized and cannot be initialized by user code. An
+/// instance is only ever created in the `free` function, which passes the
+/// instance to the closure. This allows a user to force a function to only
+/// ever be called in a critical section by taking a reference to a `CritToken`
+/// as a parameter.
+pub struct CritToken(());
 
 /// Disable interrupts, globally
 #[inline(always)]
@@ -58,13 +67,13 @@ pub unsafe fn enable() {
 /// Execute closure `f` in an interrupt-free context.
 /// This as also known as a "critical section".
 pub unsafe fn free<F, R>(f: F) -> R
-    where F: FnOnce() -> R
+    where F: FnOnce(&CritToken) -> R
 {
     let primask = ::register::primask::read();
 
     disable();
 
-    let r = f();
+    let r = f(&CritToken(()));
 
     // If the interrupts were enabled before our `disable` call, then re-enable
     // them. Otherwise, keep them disabled


### PR DESCRIPTION
This closes #11 

I just tested this locally. If you don't mind having a dev-dependency on compiletest-rs, I can add a test to demonstrate that you can't instantiate a `CritToken`, but I don't know how useful that would be...