### PR TITLE
forbid sending interrupt tokens across interrupts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["arm", "cortex-m", "register", "peripheral"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m"
 repository = "https://github.com/japaric/cortex-m"
-version = "0.2.5"
+version = "0.2.6"
 
 [dependencies]
 volatile-register = "0.2.0"

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -27,7 +27,14 @@ pub unsafe trait Nr {
     fn nr(&self) -> u8;
 }
 
-unsafe impl<T> Sync for Mutex<T> {}
+// NOTE `Mutex` can be used as a channel so, the protected data must be `Send`
+// to prevent sending non-Sendable stuff (e.g. interrupt tokens) across
+// different execution contexts (e.g. interrupts)
+unsafe impl<T> Sync for Mutex<T>
+where
+    T: Send,
+{
+}
 
 /// Disables all interrupts
 #[inline(always)]
@@ -61,7 +68,7 @@ pub unsafe fn enable() {
                  :
                  :
                  : "volatile");
-        },
+        }
         #[cfg(not(target_arch = "arm"))]
         () => {}
     }


### PR DESCRIPTION
which would break the `ctxt::Local` abstraction by making `Mutex` `Sync` only if
the protected data is `Send`. See the CHANGELOG for details. To fully fix the
memory unsafety, svd2rust needs to be updated to mark interrupt tokens as
`!Send`

cc @whitequark