### PR TITLE
add `itm::write_aligned` for writing 4-byte aligned buffers to an ITM port

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/japaric/cortex-m"
 version = "0.2.7"
 
 [dependencies]
+aligned = "0.1.1"
+cortex-m-semihosting = "0.1.3"
 volatile-register = "0.2.0"
-
-[dependencies.cortex-m-semihosting]
-version = "0.1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(naked_functions)]
 #![no_std]
 
+extern crate aligned;
 pub extern crate cortex_m_semihosting as semihosting;
 extern crate volatile_register;
 


### PR DESCRIPTION
LLVM can optimize this better and, for example, unroll the loop into a series of
32-bit writes to the ITM port