### PR TITLE
Add barrier instructions DMB, DSB, ISB

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -58,3 +58,53 @@ pub fn wfi() {
         () => {}
     }
 }
+
+/// Instruction Synchronization Barrier
+///
+/// Flushes the pipeline in the processor, so that all instructions following the `ISB` are fetched
+/// from cache or memory, after the instruction has been completed.
+pub fn isb() {
+    match () {
+        #[cfg(target_arch = "arm")]
+        () => unsafe {
+            asm!("isb 0xF" : : : "memory" : "volatile");
+        },
+        #[cfg(not(target_arch = "arm"))]
+        () => {}
+    }
+}
+
+/// Data Synchronization Barrier
+///
+/// Acts as a special kind of memory barrier. No instruction in program order after this
+/// instruction can execute until this instruction completes. This instruction completes only when
+/// both:
+///
+///  * any explicit memory access made before this instruction is complete
+///  * all cache and branch predictor maintenance operations before this instruction complete
+pub fn dsb() {
+    match () {
+        #[cfg(target_arch = "arm")]
+        () => unsafe {
+            asm!("dsb 0xF" : : : "memory" : "volatile");
+        },
+        #[cfg(not(target_arch = "arm"))]
+        () => {}
+    }
+}
+
+/// Data Memory Barrier
+///
+/// Ensures that all explicit memory accesses that appear in program order before the `DMB`
+/// instruction are observed before any explicit memory accesses that appear in program order
+/// after the `DMB` instruction.
+pub fn dmb() {
+    match () {
+        #[cfg(target_arch = "arm")]
+        () => unsafe {
+            asm!("dmb 0xF" : : : "memory" : "volatile");
+        },
+        #[cfg(not(target_arch = "arm"))]
+        () => {}
+    }
+}


### PR DESCRIPTION
These instructions (A6.7.21-24 in ARMv6-M reference and A7.7.32-36 in ARMv7-M reference) allow explicit instruction and memory synchronisation. They're necessary for dealing with caches in Cortex-M7 parts and for various DMA operations on other parts.

Since they exist in both ARMv6-M and ARMv7-M I've added them as `#[cfg(target_arch="arm")]` but maybe there's a better cfg flag?

The argument `0xF` is the only permitted encoding. They are all marked volatile and as clobbering memory in the CMSIS C implementation.