### PR TITLE
Add cache maintenance functions for ARMv7-M

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,6 @@ fn main() {
         println!("cargo:rustc-cfg=armv7m");
     } else if target.starts_with("thumbv7em-") {
         println!("cargo:rustc-cfg=armv7m");
-        println!("cargo:rustc-cfg=armv7em");
+        //println!("cargo:rustc-cfg=armv7em");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,11 @@ fn main() {
     let target = env::var("TARGET").unwrap();
 
     if target.starts_with("thumbv6m-") {
-        println!("cargo:rustc-cfg=armv6m")
+        println!("cargo:rustc-cfg=armv6m");
+    } else if target.starts_with("thumbv7m-") {
+        println!("cargo:rustc-cfg=armv7m");
+    } else if target.starts_with("thumbv7em-") {
+        println!("cargo:rustc-cfg=armv7m");
+        println!("cargo:rustc-cfg=armv7em");
     }
 }

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -1005,6 +1005,8 @@ impl Cbp {
     }
 
     /// D-cache invalidate by set-way
+    ///
+    /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
     #[inline(always)]
     pub fn dcisw(&self, set: u16, way: u16) {
         // The ARMv7-M Architecture Reference Manual, as of Revision E.b, says these set/way
@@ -1035,6 +1037,8 @@ impl Cbp {
     }
 
     /// D-cache clean by set-way
+    ///
+    /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
     #[inline(always)]
     pub fn dccsw(&self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
@@ -1051,6 +1055,8 @@ impl Cbp {
     }
 
     /// D-cache clean and invalidate by set-way
+    ///
+    /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
     #[inline(always)]
     pub fn dccisw(&self, set: u16, way: u16) {
         // See comment for dcisw() about the format here

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -137,8 +137,9 @@ impl Cpuid {
     ///
     /// * `level`: the required cache level minus 1, e.g. 0 for L1, 1 for L2
     /// * `ind`: select instruction cache or data/unified cache
+    ///
+    /// `level` is masked to be between 0 and 7.
     pub fn select_cache(&self, level: u8, ind: CsselrCacheType) {
-        assert!(level<8);
         unsafe { self.csselr.write(
             (((level as u32) << CSSELR_LEVEL_POS) & CSSELR_LEVEL_MASK) |
             (((ind   as u32) <<   CSSELR_IND_POS) &   CSSELR_IND_MASK)

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -934,7 +934,7 @@ pub struct Tpiu {
 pub struct Cbp {
     /// I-cache invalidate all to PoU
     pub iciallu: WO<u32>,
-    reserved0: RW<u32>,
+    reserved0: u32,
     /// I-cache invalidate by MVA to PoU
     pub icimvau: WO<u32>,
     /// D-cache invalidate by MVA to PoC

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -623,9 +623,13 @@ impl Scb {
     }
 
     /// Invalidates D-cache
+    ///
+    /// Note that calling this while the dcache is enabled will probably wipe out your
+    /// stack, depending on optimisations, breaking returning to the call point.
+    /// It's used immediately before enabling the dcache, but not exported publicly.
     #[cfg(armv7m)]
     #[inline]
-    pub fn invalidate_dcache(&self, cpuid: &Cpuid) {
+    fn invalidate_dcache(&self, cpuid: &Cpuid) {
         // All of CBP is write-only so no data races are possible
         let cbp = unsafe { &mut *CBP.get() };
 

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -113,15 +113,6 @@ pub struct Cpuid {
     pub csselr: RW<u32>,
 }
 
-const CSSELR_IND_POS: u32 = 0;
-const CSSELR_IND_MASK: u32 = 1 << CSSELR_IND_POS;
-const CSSELR_LEVEL_POS: u32 = 1;
-const CSSELR_LEVEL_MASK: u32 = 0x7 << CSSELR_LEVEL_POS;
-const CCSIDR_NUMSETS_POS: u32 = 13;
-const CCSIDR_NUMSETS_MASK: u32 = 0x7FFF << CCSIDR_NUMSETS_POS;
-const CCSIDR_ASSOCIATIVITY_POS: u32 = 3;
-const CCSIDR_ASSOCIATIVITY_MASK: u32 = 0x3FF << CCSIDR_ASSOCIATIVITY_POS;
-
 /// Type of cache to select on CSSELR writes.
 #[cfg(armv7m)]
 pub enum CsselrCacheType {
@@ -140,6 +131,11 @@ impl Cpuid {
     ///
     /// `level` is masked to be between 0 and 7.
     pub fn select_cache(&self, level: u8, ind: CsselrCacheType) {
+        const CSSELR_IND_POS: u32 = 0;
+        const CSSELR_IND_MASK: u32 = 1 << CSSELR_IND_POS;
+        const CSSELR_LEVEL_POS: u32 = 1;
+        const CSSELR_LEVEL_MASK: u32 = 0x7 << CSSELR_LEVEL_POS;
+
         unsafe { self.csselr.write(
             (((level as u32) << CSSELR_LEVEL_POS) & CSSELR_LEVEL_MASK) |
             (((ind   as u32) <<   CSSELR_IND_POS) &   CSSELR_IND_MASK)
@@ -148,6 +144,11 @@ impl Cpuid {
 
     /// Returns the number of sets and ways in the selected cache
     pub fn cache_num_sets_ways(&self, level: u8, ind: CsselrCacheType) -> (u16, u16) {
+        const CCSIDR_NUMSETS_POS: u32 = 13;
+        const CCSIDR_NUMSETS_MASK: u32 = 0x7FFF << CCSIDR_NUMSETS_POS;
+        const CCSIDR_ASSOCIATIVITY_POS: u32 = 3;
+        const CCSIDR_ASSOCIATIVITY_MASK: u32 = 0x3FF << CCSIDR_ASSOCIATIVITY_POS;
+
         self.select_cache(level, ind);
         ::asm::dsb();
         let ccsidr = self.ccsidr.read();
@@ -490,9 +491,6 @@ pub enum FpuAccessMode {
     Privileged,
 }
 
-const SCB_CCR_IC_MASK: u32 = (1<<17);
-const SCB_CCR_DC_MASK: u32 = (1<<16);
-
 const SCB_CPACR_FPU_MASK: u32 = 0b11_11 << 20;
 const SCB_CPACR_FPU_ENABLE: u32 = 0b01_01 << 20;
 const SCB_CPACR_FPU_USER: u32 = 0b10_10 << 20;
@@ -535,6 +533,15 @@ impl Scb {
         self.set_fpu_access_mode(FpuAccessMode::Disabled)
     }
 }
+
+#[cfg(armv7m)]
+mod scb_consts {
+    pub const SCB_CCR_IC_MASK: u32 = (1<<17);
+    pub const SCB_CCR_DC_MASK: u32 = (1<<16);
+}
+
+#[cfg(armv7m)]
+use self::scb_consts::*;
 
 #[cfg(armv7m)]
 impl Scb {
@@ -996,10 +1003,16 @@ pub struct Cbp {
     pub bpiall: WO<u32>,
 }
 
-const CBP_SW_WAY_POS: u32 = 30;
-const CBP_SW_WAY_MASK: u32 = 0x3 << CBP_SW_WAY_POS;
-const CBP_SW_SET_POS: u32 = 5;
-const CBP_SW_SET_MASK: u32 = 0x1FF << CBP_SW_SET_POS;
+#[cfg(armv7m)]
+mod cbp_consts {
+    pub const CBP_SW_WAY_POS: u32 = 30;
+    pub const CBP_SW_WAY_MASK: u32 = 0x3 << CBP_SW_WAY_POS;
+    pub const CBP_SW_SET_POS: u32 = 5;
+    pub const CBP_SW_SET_MASK: u32 = 0x1FF << CBP_SW_SET_POS;
+}
+
+#[cfg(armv7m)]
+use self::cbp_consts::*;
 
 #[cfg(armv7m)]
 impl Cbp {

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -682,8 +682,11 @@ impl Scb {
 
     /// Invalidates D-cache by address
     ///
-    /// `addr`: the address to invalidate, aligned to 32-byte boundary
-    /// `size`: size of the memory block, in number of bytes, a multiple of 32
+    /// `addr`: the address to invalidate
+    /// `size`: size of the memory block, in number of bytes
+    ///
+    /// Invalidates cache starting from the lowest 32-byte aligned address represented by `addr`,
+    /// in blocks of 32 bytes until at least `size` bytes have been invalidated.
     #[inline]
     pub fn invalidate_dcache_by_address(&self, addr: u32, size: u32) {
         // All of CBP is write-only so no data races are possible
@@ -691,10 +694,11 @@ impl Scb {
 
         ::asm::dsb();
 
+
         // Cache lines are fixed to 32 bit on Cortex-M7 and not present in earlier Cortex-M
         const LINESIZE: u32 = 32;
 
-        let mut addr = addr;
+        let mut addr = addr & 0xFFFF_FFE0;
 
         for _ in 0..(size/LINESIZE) {
             cbp.dcimvac(addr);
@@ -707,8 +711,11 @@ impl Scb {
 
     /// Cleans D-cache by address
     ///
-    /// `addr`: the address to clean, aligned to 32-byte boundary
-    /// `size`: size of the memory block, in number of bytes, a multiple of 32
+    /// `addr`: the address to clean
+    /// `size`: size of the memory block, in number of bytes
+    ///
+    /// Cleans cache starting from the lowest 32-byte aligned address represented by `addr`,
+    /// in blocks of 32 bytes until at least `size` bytes have been cleaned.
     #[inline]
     pub fn clean_dcache_by_address(&self, addr: u32, size: u32) {
         // All of CBP is write-only so no data races are possible
@@ -719,7 +726,7 @@ impl Scb {
         // Cache lines are fixed to 32 bit on Cortex-M7 and not present in earlier Cortex-M
         const LINESIZE: u32 = 32;
 
-        let mut addr = addr;
+        let mut addr = addr & 0xFFFF_FFE0;
 
         for _ in 0..(size/LINESIZE) {
             cbp.dccmvac(addr);
@@ -732,8 +739,12 @@ impl Scb {
 
     /// Cleans and invalidates D-cache by address
     ///
-    /// `addr`: the address to clean and invalidate, aligned to 32-byte boundary
-    /// `size`: size of the memory block, in number of bytes, a multiple of 32
+    /// `addr`: the address to clean and invalidate
+    /// `size`: size of the memory block, in number of bytes
+    ///
+    /// Cleans and invalidates cache starting from the lowest 32-byte aligned address represented
+    /// by `addr`, in blocks of 32 bytes until at least `size` bytes have been cleaned and
+    /// invalidated.
     #[inline]
     pub fn clean_invalidate_dcache_by_address(&self, addr: u32, size: u32) {
         // All of CBP is write-only so no data races are possible
@@ -744,7 +755,7 @@ impl Scb {
         // Cache lines are fixed to 32 bit on Cortex-M7 and not present in earlier Cortex-M
         const LINESIZE: u32 = 32;
 
-        let mut addr = addr;
+        let mut addr = addr & 0xFFFF_FFE0;
 
         for _ in 0..(size/LINESIZE) {
             cbp.dccimvac(addr);

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -712,20 +712,25 @@ impl Scb {
     /// Invalidates cache starting from the lowest 32-byte aligned address represented by `addr`,
     /// in blocks of 32 bytes until at least `size` bytes have been invalidated.
     #[inline]
-    pub fn invalidate_dcache_by_address(&self, addr: u32, size: u32) {
+    pub fn invalidate_dcache_by_address(&self, addr: usize, size: usize) {
+        // No-op zero sized operations
+        if size == 0 {
+            return;
+        }
+
         // All of CBP is write-only so no data races are possible
         let cbp = unsafe { &mut *CBP.get() };
 
         ::asm::dsb();
 
-
         // Cache lines are fixed to 32 bit on Cortex-M7 and not present in earlier Cortex-M
-        const LINESIZE: u32 = 32;
+        const LINESIZE: usize = 32;
+        let num_lines = ((size - 1)/LINESIZE) + 1;
 
         let mut addr = addr & 0xFFFF_FFE0;
 
-        for _ in 0..(size/LINESIZE) {
-            cbp.dcimvac(addr);
+        for _ in 0..num_lines {
+            cbp.dcimvac(addr as u32);
             addr += LINESIZE;
         }
 
@@ -741,19 +746,25 @@ impl Scb {
     /// Cleans cache starting from the lowest 32-byte aligned address represented by `addr`,
     /// in blocks of 32 bytes until at least `size` bytes have been cleaned.
     #[inline]
-    pub fn clean_dcache_by_address(&self, addr: u32, size: u32) {
+    pub fn clean_dcache_by_address(&self, addr: usize, size: usize) {
+        // No-op zero sized operations
+        if size == 0 {
+            return;
+        }
+
         // All of CBP is write-only so no data races are possible
         let cbp = unsafe { &mut *CBP.get() };
 
         ::asm::dsb();
 
         // Cache lines are fixed to 32 bit on Cortex-M7 and not present in earlier Cortex-M
-        const LINESIZE: u32 = 32;
+        const LINESIZE: usize = 32;
+        let num_lines = ((size - 1)/LINESIZE) + 1;
 
         let mut addr = addr & 0xFFFF_FFE0;
 
-        for _ in 0..(size/LINESIZE) {
-            cbp.dccmvac(addr);
+        for _ in 0..num_lines {
+            cbp.dccmvac(addr as u32);
             addr += LINESIZE;
         }
 
@@ -770,19 +781,25 @@ impl Scb {
     /// by `addr`, in blocks of 32 bytes until at least `size` bytes have been cleaned and
     /// invalidated.
     #[inline]
-    pub fn clean_invalidate_dcache_by_address(&self, addr: u32, size: u32) {
+    pub fn clean_invalidate_dcache_by_address(&self, addr: usize, size: usize) {
+        // No-op zero sized operations
+        if size == 0 {
+            return;
+        }
+
         // All of CBP is write-only so no data races are possible
         let cbp = unsafe { &mut *CBP.get() };
 
         ::asm::dsb();
 
         // Cache lines are fixed to 32 bit on Cortex-M7 and not present in earlier Cortex-M
-        const LINESIZE: u32 = 32;
+        const LINESIZE: usize = 32;
+        let num_lines = ((size - 1)/LINESIZE) + 1;
 
         let mut addr = addr & 0xFFFF_FFE0;
 
-        for _ in 0..(size/LINESIZE) {
-            cbp.dccimvac(addr);
+        for _ in 0..num_lines {
+            cbp.dccimvac(addr as u32);
             addr += LINESIZE;
         }
 

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -1019,8 +1019,8 @@ impl Cbp {
         // Cortex-M7 have a DCACHE or ICACHE at all, it seems safe to do the same thing as the
         // CMSIS-Core implementation and use fixed values.
         unsafe { self.dcisw.write(
-            (((way as u32) << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
-            (((set as u32) << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
+            (((way as u32) & (CBP_SW_WAY_MASK >> CBP_SW_WAY_POS)) << CBP_SW_WAY_POS) |
+            (((set as u32) & (CBP_SW_SET_MASK >> CBP_SW_SET_POS)) << CBP_SW_SET_POS));
         }
     }
 
@@ -1043,8 +1043,8 @@ impl Cbp {
     pub fn dccsw(&self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
         unsafe { self.dccsw.write(
-            (((way as u32) << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
-            (((set as u32) << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
+            (((way as u32) & (CBP_SW_WAY_MASK >> CBP_SW_WAY_POS)) << CBP_SW_WAY_POS) |
+            (((set as u32) & (CBP_SW_SET_MASK >> CBP_SW_SET_POS)) << CBP_SW_SET_POS));
         }
     }
 
@@ -1061,8 +1061,8 @@ impl Cbp {
     pub fn dccisw(&self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
         unsafe { self.dccisw.write(
-            (((way as u32) << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
-            (((set as u32) << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
+            (((way as u32) & (CBP_SW_WAY_MASK >> CBP_SW_WAY_POS)) << CBP_SW_WAY_POS) |
+            (((set as u32) & (CBP_SW_SET_MASK >> CBP_SW_SET_POS)) << CBP_SW_SET_POS));
         }
     }
 

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -148,20 +148,14 @@ impl Cpuid {
         )}
     }
 
-    /// Returns the number of sets in the selected cache
+    /// Returns the number of sets and ways in the selected cache
     #[cfg(armv7m)]
-    pub fn cache_num_sets(&self, level: u32, ind: u32) -> u32 {
+    pub fn cache_num_sets_ways(&self, level: u32, ind: u32) -> (u32, u32) {
         self.select_cache(level, ind);
         ::asm::dsb();
-        1 + ((self.ccsidr.read() & CCSIDR_NUMSETS_MASK) >> CCSIDR_NUMSETS_POS)
-    }
-
-    /// Returns the number of ways in the selected cache
-    #[cfg(armv7m)]
-    pub fn cache_num_ways(&self, level: u32, ind: u32) -> u32 {
-        self.select_cache(level, ind);
-        ::asm::dsb();
-        1 + ((self.ccsidr.read() & CCSIDR_ASSOCIATIVITY_MASK) >> CCSIDR_ASSOCIATIVITY_POS)
+        let ccsidr = self.ccsidr.read();
+        (1 + ((ccsidr & CCSIDR_NUMSETS_MASK) >> CCSIDR_NUMSETS_POS),
+         1 + ((ccsidr & CCSIDR_ASSOCIATIVITY_MASK) >> CCSIDR_ASSOCIATIVITY_POS))
     }
 }
 
@@ -636,8 +630,7 @@ impl Scb {
         let cbp = unsafe { &mut *CBP.get() };
 
         // Read number of sets and ways
-        let sets = cpuid.cache_num_sets(0, 0);
-        let ways = cpuid.cache_num_ways(0, 0);
+        let (sets, ways) = cpuid.cache_num_sets_ways(0, 0);
 
         // Invalidate entire D-Cache
         for set in 0..sets {
@@ -658,8 +651,7 @@ impl Scb {
         let cbp = unsafe { &mut *CBP.get() };
 
         // Read number of sets and ways
-        let sets = cpuid.cache_num_sets(0, 0);
-        let ways = cpuid.cache_num_ways(0, 0);
+        let (sets, ways) = cpuid.cache_num_sets_ways(0, 0);
 
         for set in 0..sets {
             for way in 0..ways {
@@ -679,8 +671,7 @@ impl Scb {
         let cbp = unsafe { &mut *CBP.get() };
 
         // Read number of sets and ways
-        let sets = cpuid.cache_num_sets(0, 0);
-        let ways = cpuid.cache_num_ways(0, 0);
+        let (sets, ways) = cpuid.cache_num_sets_ways(0, 0);
 
         for set in 0..sets {
             for way in 0..ways {

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -117,23 +117,14 @@ pub struct Cpuid {
     pub csselr: RW<u32>,
 }
 
-#[cfg(armv7m)]
 const CSSELR_IND_POS: u32 = 0;
-#[cfg(armv7m)]
 const CSSELR_IND_MASK: u32 = 1 << CSSELR_IND_POS;
-#[cfg(armv7m)]
 const CSSELR_LEVEL_POS: u32 = 1;
-#[cfg(armv7m)]
 const CSSELR_LEVEL_MASK: u32 = 0x7 << CSSELR_LEVEL_POS;
-#[cfg(armv7m)]
 const CCSIDR_NUMSETS_POS: u32 = 13;
-#[cfg(armv7m)]
 const CCSIDR_NUMSETS_MASK: u32 = 0x7FFF << CCSIDR_NUMSETS_POS;
-#[cfg(armv7m)]
 const CCSIDR_ASSOCIATIVITY_POS: u32 = 3;
-#[cfg(armv7m)]
 const CCSIDR_ASSOCIATIVITY_MASK: u32 = 0x3FF << CCSIDR_ASSOCIATIVITY_POS;
-
 
 impl Cpuid {
     /// Selects the current CCSIDR
@@ -493,9 +484,7 @@ pub enum FpuAccessMode {
     Privileged,
 }
 
-#[cfg(armv7m)]
 const SCB_CCR_IC_MASK: u32 = (1<<17);
-#[cfg(armv7m)]
 const SCB_CCR_DC_MASK: u32 = (1<<16);
 
 const SCB_CPACR_FPU_MASK: u32 = 0b11_11 << 20;
@@ -539,9 +528,11 @@ impl Scb {
     pub fn disable_fpu(&self) {
         self.set_fpu_access_mode(FpuAccessMode::Disabled)
     }
+}
 
+#[cfg(armv7m)]
+impl Scb {
     /// Enables I-Cache
-    #[cfg(armv7m)]
     #[inline]
     pub fn enable_icache(&self) {
         // All of CBP is write-only so no data races are possible
@@ -561,7 +552,6 @@ impl Scb {
     }
 
     /// Disables I-Cache
-    #[cfg(armv7m)]
     #[inline]
     pub fn disable_icache(&self) {
         // All of CBP is write-only so no data races are possible
@@ -581,7 +571,6 @@ impl Scb {
     }
 
     /// Invalidates I-Cache
-    #[cfg(armv7m)]
     #[inline]
     pub fn invalidate_icache(&self) {
         // All of CBP is write-only so no data races are possible
@@ -598,7 +587,6 @@ impl Scb {
     }
 
     /// Enables D-cache
-    #[cfg(armv7m)]
     #[inline]
     pub fn enable_dcache(&self, cpuid: &Cpuid) {
         // Invalidate anything currently in the DCache
@@ -612,7 +600,6 @@ impl Scb {
     }
 
     /// Disables D-cache
-    #[cfg(armv7m)]
     #[inline]
     pub fn disable_dcache(&self, cpuid: &Cpuid) {
         // Turn off the DCache
@@ -627,7 +614,6 @@ impl Scb {
     /// Note that calling this while the dcache is enabled will probably wipe out your
     /// stack, depending on optimisations, breaking returning to the call point.
     /// It's used immediately before enabling the dcache, but not exported publicly.
-    #[cfg(armv7m)]
     #[inline]
     fn invalidate_dcache(&self, cpuid: &Cpuid) {
         // All of CBP is write-only so no data races are possible
@@ -648,7 +634,6 @@ impl Scb {
     }
 
     /// Cleans D-cache
-    #[cfg(armv7m)]
     #[inline]
     pub fn clean_dcache(&self, cpuid: &Cpuid) {
         // All of CBP is write-only so no data races are possible
@@ -668,7 +653,6 @@ impl Scb {
     }
 
     /// Cleans and invalidates D-cache
-    #[cfg(armv7m)]
     #[inline]
     pub fn clean_invalidate_dcache(&self, cpuid: &Cpuid) {
         // All of CBP is write-only so no data races are possible
@@ -691,7 +675,6 @@ impl Scb {
     ///
     /// `addr`: the address to invalidate, aligned to 32-byte boundary
     /// `size`: size of the memory block, in number of bytes, a multiple of 32
-    #[cfg(armv7m)]
     #[inline]
     pub fn invalidate_dcache_by_address(&self, addr: u32, size: u32) {
         // All of CBP is write-only so no data races are possible
@@ -717,7 +700,6 @@ impl Scb {
     ///
     /// `addr`: the address to clean, aligned to 32-byte boundary
     /// `size`: size of the memory block, in number of bytes, a multiple of 32
-    #[cfg(armv7m)]
     #[inline]
     pub fn clean_dcache_by_address(&self, addr: u32, size: u32) {
         // All of CBP is write-only so no data races are possible
@@ -743,7 +725,6 @@ impl Scb {
     ///
     /// `addr`: the address to clean and invalidate, aligned to 32-byte boundary
     /// `size`: size of the memory block, in number of bytes, a multiple of 32
-    #[cfg(armv7m)]
     #[inline]
     pub fn clean_invalidate_dcache_by_address(&self, addr: u32, size: u32) {
         // All of CBP is write-only so no data races are possible
@@ -954,13 +935,9 @@ pub struct Cbp {
     pub bpiall: WO<u32>,
 }
 
-#[cfg(armv7m)]
 const CBP_SW_WAY_POS: u32 = 30;
-#[cfg(armv7m)]
 const CBP_SW_WAY_MASK: u32 = 0x3 << CBP_SW_WAY_POS;
-#[cfg(armv7m)]
 const CBP_SW_SET_POS: u32 = 5;
-#[cfg(armv7m)]
 const CBP_SW_SET_MASK: u32 = 0x1FF << CBP_SW_SET_POS;
 
 #[cfg(armv7m)]

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -104,16 +104,12 @@ pub struct Cpuid {
     pub isar: [RO<u32>; 5],
     reserved1: u32,
     /// Cache Level ID
-    #[cfg(armv7m)]
     pub clidr: RO<u32>,
     /// Cache Type
-    #[cfg(armv7m)]
     pub ctr: RO<u32>,
     /// Cache Size ID
-    #[cfg(armv7m)]
     pub ccsidr: RO<u32>,
     /// Cache Size Selection
-    #[cfg(armv7m)]
     pub csselr: RW<u32>,
 }
 

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -150,12 +150,12 @@ impl Cpuid {
     }
 
     /// Returns the number of sets and ways in the selected cache
-    pub fn cache_num_sets_ways(&self, level: u8, ind: CsselrCacheType) -> (u32, u32) {
+    pub fn cache_num_sets_ways(&self, level: u8, ind: CsselrCacheType) -> (u16, u16) {
         self.select_cache(level, ind);
         ::asm::dsb();
         let ccsidr = self.ccsidr.read();
-        (1 + ((ccsidr & CCSIDR_NUMSETS_MASK) >> CCSIDR_NUMSETS_POS),
-         1 + ((ccsidr & CCSIDR_ASSOCIATIVITY_MASK) >> CCSIDR_ASSOCIATIVITY_POS))
+        ((1 + ((ccsidr & CCSIDR_NUMSETS_MASK) >> CCSIDR_NUMSETS_POS)) as u16,
+         (1 + ((ccsidr & CCSIDR_ASSOCIATIVITY_MASK) >> CCSIDR_ASSOCIATIVITY_POS)) as u16)
     }
 }
 
@@ -971,7 +971,7 @@ impl Cbp {
 
     /// D-cache invalidate by set-way
     #[inline(always)]
-    pub fn dcisw(&self, set: u32, way: u32) {
+    pub fn dcisw(&self, set: u16, way: u16) {
         // The ARMv7-M Architecture Reference Manual, as of Revision E.b, says these set/way
         // operations have a register data format which depends on the implementation's
         // associativity and number of sets. Specifically the 'way' and 'set' fields have
@@ -982,8 +982,8 @@ impl Cbp {
         // Cortex-M7 have a DCACHE or ICACHE at all, it seems safe to do the same thing as the
         // CMSIS-Core implementation and use fixed values.
         unsafe { self.dcisw.write(
-            ((way << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
-            ((set << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
+            (((way as u32) << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
+            (((set as u32) << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
         }
     }
 
@@ -1001,11 +1001,11 @@ impl Cbp {
 
     /// D-cache clean by set-way
     #[inline(always)]
-    pub fn dccsw(&self, set: u32, way: u32) {
+    pub fn dccsw(&self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
         unsafe { self.dccsw.write(
-            ((way << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
-            ((set << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
+            (((way as u32) << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
+            (((set as u32) << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
         }
     }
 
@@ -1017,11 +1017,11 @@ impl Cbp {
 
     /// D-cache clean and invalidate by set-way
     #[inline(always)]
-    pub fn dccisw(&self, set: u32, way: u32) {
+    pub fn dccisw(&self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
         unsafe { self.dccisw.write(
-            ((way << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
-            ((set << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
+            (((way as u32) << CBP_SW_WAY_POS) & CBP_SW_WAY_MASK) |
+            (((set as u32) << CBP_SW_SET_POS) & CBP_SW_SET_MASK));
         }
     }
 


### PR DESCRIPTION
This PR adds the cache control primitives, and the higher-level cache maintenance operations that are also present in CMSIS. Cortex-M7 devices generally have a DCache and ICache which can sometimes be useful (mostly if you have external RAM) but you need to specifically clean and invalidate cache entries to ensure coherency between the CPU and DMA or other bus masters.

Specifically, this PR:

* Extends the config flags to include armv7m and armv7em (with -M also being set for -EM parts)
* Puts the existing CLIDR, CTR, CCSIDR, and CSSELR CPUID registers behind cfg(armv7m) as they are only implemented since ARMv7-M.
    * CSSELR is changed to RW - though the table B4-1 says it's RO, the specific information in B4.8.3 says it is RW, and it's used by writing to it.
* Adds methods on CPUID to access those cache related registers and retrieve cache number of sets/ways
* Adds the CBP memory-mapped operations block from Table B2-1, which contains operations to clean and invalidate the instruction and data caches and branch predictor on ARMv7-M parts that include them.
* Adds methods for each of the memory locations in the CBP block to actually perform those operations, with appropriate arguments.
     * Though note the set/way functions are specific to Cortex-M7 and might not apply to a future ARMv7-M implementation with a different cache setup (see the comment in `dcisw()`)
* Adds new methods to SCB that mirror the equivalent SCB_* cache functions in CMSIS (see [core_cm7.h](https://github.com/ARM-software/CMSIS/blob/master/CMSIS/Include/core_cm7.h)).

All table/section references refer to the ARMv7-M architecture reference manual.

Testing that these worked as expected was as fun as you'd imagine but I'm confident they do what's expected and match the CMSIS implementation.

```
Running cache test...
Operation               Cache  RAM
----------------------------------
Initial....................A    A
Increment..................B    B
Enable DCache..............B    B
Increment..................C    B
Clean DCache...............C    C
Increment..................D    C
Invalidate DCache..........C    C
Increment..................D    C
CleanInvalidate DCache.....D    D
Increment..................E    D
Clean DCache wrong addr....E    D
Clean DCache right addr....E    E
Increment..................F    E
Inval DCache wrong addr....F    E
Inval DCache right addr....E    E
Increment..................F    E
CI DCache wrong addr.......F    E
CI DCache right addr.......F    F
Increment..................G    F
Disable DCache.............G    G
```

A few open questions...

* I'm not super happy at how you have to pass &cpuid into some of the SCB cache methods, but I can't see any nice way around this. The functions are in SCB to match the `SCB_CleanDCache()` macros from CMSIS and because the key cache enable bits are in SCB, but you could imagine moving these to methods on CBP instead.
* The SCB methods currently accesses the CBP block with `get()` but as this whole block is WO, stateless, and just consists of memory-mapped operations, I assume this isn't a problem.
* Calling `invalidate_dcache` while the dcache is enabled is generally a poor idea: your stack including callstack could be reset to some older state among other problems. If you build this with optimisations, `invalidate_dcache` gets inlined and uses registers enough that it will complete and do what you expect, but if the cache contains anything that should have been cleaned you will get some unexpected results. If you build without optimisations, it will just get stuck in the invalidate loop as the loop counter update gets wiped out. I wrote an inlineable asm version which solves this specific problem, but still means your stack will probably not be correct, and it's a bunch messier, so I think this simple non-asm version is the one to use. Since disabling the DCache also does a clean and invalidate afterwards, it's not clear when you'd actually want to call `invalidate_dcache` (outside of `enable_dcache` which calls it before enabling the cache). I included it because it's in CMSIS.