### PR TITLE
Issue DSB; ISB after changing FPU status to ensure completion

### DIFF
--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -11,6 +11,7 @@ use core::ptr;
 use volatile_register::{RO, RW, WO};
 
 use interrupt::{CriticalSection, Nr};
+use asm;
 
 #[cfg(test)]
 mod test;
@@ -473,6 +474,8 @@ impl Scb {
             }
         }
         unsafe { self.cpacr.write(cpacr) }
+        asm::dsb();
+        asm::isb();
     }
 
     /// Shorthand for `set_fpu_access_mode(FpuAccessMode::Enabled)`


### PR DESCRIPTION
This is necessary according to ARM, I suppose if some VFP op got scheduled right after an inlined FPU enable it would be trouble.