### PR TITLE
add Formatter and Flush Control Register to struct TPIU

### DIFF
--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -950,12 +950,15 @@ pub struct TPIU {
     reserved1: [u32; 55],
     /// Selected Pin Control
     pub sppr: RW<u32>,
-    reserved2: [u32; 943],
+    reserved2: [u32; 132],
+    /// Formatter and Flush Control
+    pub ffcr: RW<u32>,
+    reserved3: [u32; 810],
     /// Lock Access
     pub lar: WO<u32>,
     /// Lock Status
     pub lsr: RO<u32>,
-    reserved3: [u32; 4],
+    reserved4: [u32; 4],
     /// TPIU Type
     pub _type: RO<u32>,
 }

--- a/src/peripheral/test.rs
+++ b/src/peripheral/test.rs
@@ -157,6 +157,7 @@ fn tpiu() {
     assert_eq!(address(&tpiu.cspsr), 0xE004_0004);
     assert_eq!(address(&tpiu.acpr), 0xE004_0010);
     assert_eq!(address(&tpiu.sppr), 0xE004_00F0);
+    assert_eq!(address(&tpiu.ffcr), 0xE004_0304);
     assert_eq!(address(&tpiu.lar), 0xE004_0FB0);
     assert_eq!(address(&tpiu.lsr), 0xE004_0FB4);
     assert_eq!(address(&tpiu._type), 0xE004_0FC8);


### PR DESCRIPTION
When using [Black Magic Probe](https://github.com/blacksphere/blackmagic/wiki) with traceswo (itm) debugging, the debugger hardware doesn't initialize the target to enable tracing. Instead, one should do setup the target from application code.

While implementing that setup code, I noticed that I couldn't disable the TPIU formatter, because the 'Formatter and Flush Control Register' was not exposed by the cortex-m crate.

This patch adds that register.