### PR TITLE
revise peripheral API

### DIFF
--- a/src/exception.rs
+++ b/src/exception.rs
@@ -22,8 +22,7 @@ pub enum Exception {
     /// An interrupt
     Interrupt(u8),
     // Unreachable variant
-    #[doc(hidden)]
-    Reserved,
+    #[doc(hidden)] Reserved,
 }
 
 impl Exception {

--- a/src/peripheral/cbp.rs
+++ b/src/peripheral/cbp.rs
@@ -2,6 +2,8 @@
 
 use volatile_register::WO;
 
+use peripheral::CBP;
+
 /// Register block
 #[repr(C)]
 pub struct RegisterBlock {
@@ -33,10 +35,10 @@ const CBP_SW_WAY_MASK: u32 = 0x3 << CBP_SW_WAY_POS;
 const CBP_SW_SET_POS: u32 = 5;
 const CBP_SW_SET_MASK: u32 = 0x1FF << CBP_SW_SET_POS;
 
-impl RegisterBlock {
+impl CBP {
     /// I-cache invalidate all to PoU
     #[inline]
-    pub fn iciallu(&self) {
+    pub fn iciallu(&mut self) {
         unsafe {
             self.iciallu.write(0);
         }
@@ -44,7 +46,7 @@ impl RegisterBlock {
 
     /// I-cache invalidate by MVA to PoU
     #[inline]
-    pub fn icimvau(&self, mva: u32) {
+    pub fn icimvau(&mut self, mva: u32) {
         unsafe {
             self.icimvau.write(mva);
         }
@@ -52,7 +54,7 @@ impl RegisterBlock {
 
     /// D-cache invalidate by MVA to PoC
     #[inline]
-    pub fn dcimvac(&self, mva: u32) {
+    pub fn dcimvac(&mut self, mva: u32) {
         unsafe {
             self.dcimvac.write(mva);
         }
@@ -62,7 +64,7 @@ impl RegisterBlock {
     ///
     /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
     #[inline]
-    pub fn dcisw(&self, set: u16, way: u16) {
+    pub fn dcisw(&mut self, set: u16, way: u16) {
         // The ARMv7-M Architecture Reference Manual, as of Revision E.b, says these set/way
         // operations have a register data format which depends on the implementation's
         // associativity and number of sets. Specifically the 'way' and 'set' fields have
@@ -82,7 +84,7 @@ impl RegisterBlock {
 
     /// D-cache clean by MVA to PoU
     #[inline]
-    pub fn dccmvau(&self, mva: u32) {
+    pub fn dccmvau(&mut self, mva: u32) {
         unsafe {
             self.dccmvau.write(mva);
         }
@@ -90,7 +92,7 @@ impl RegisterBlock {
 
     /// D-cache clean by MVA to PoC
     #[inline]
-    pub fn dccmvac(&self, mva: u32) {
+    pub fn dccmvac(&mut self, mva: u32) {
         unsafe {
             self.dccmvac.write(mva);
         }
@@ -100,7 +102,7 @@ impl RegisterBlock {
     ///
     /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
     #[inline]
-    pub fn dccsw(&self, set: u16, way: u16) {
+    pub fn dccsw(&mut self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
         unsafe {
             self.dccsw.write(
@@ -112,7 +114,7 @@ impl RegisterBlock {
 
     /// D-cache clean and invalidate by MVA to PoC
     #[inline]
-    pub fn dccimvac(&self, mva: u32) {
+    pub fn dccimvac(&mut self, mva: u32) {
         unsafe {
             self.dccimvac.write(mva);
         }
@@ -122,7 +124,7 @@ impl RegisterBlock {
     ///
     /// `set` is masked to be between 0 and 3, and `way` between 0 and 511.
     #[inline]
-    pub fn dccisw(&self, set: u16, way: u16) {
+    pub fn dccisw(&mut self, set: u16, way: u16) {
         // See comment for dcisw() about the format here
         unsafe {
             self.dccisw.write(
@@ -134,7 +136,7 @@ impl RegisterBlock {
 
     /// Branch predictor invalidate all
     #[inline]
-    pub fn bpiall(&self) {
+    pub fn bpiall(&mut self) {
         unsafe {
             self.bpiall.write(0);
         }

--- a/src/peripheral/cpuid.rs
+++ b/src/peripheral/cpuid.rs
@@ -4,6 +4,9 @@ use volatile_register::RO;
 #[cfg(any(armv7m, test))]
 use volatile_register::RW;
 
+#[cfg(armv7m)]
+use peripheral::CPUID;
+
 /// Register block
 #[repr(C)]
 pub struct RegisterBlock {
@@ -45,14 +48,14 @@ pub enum CsselrCacheType {
 }
 
 #[cfg(armv7m)]
-impl RegisterBlock {
+impl CPUID {
     /// Selects the current CCSIDR
     ///
     /// * `level`: the required cache level minus 1, e.g. 0 for L1, 1 for L2
     /// * `ind`: select instruction cache or data/unified cache
     ///
     /// `level` is masked to be between 0 and 7.
-    pub fn select_cache(&self, level: u8, ind: CsselrCacheType) {
+    pub fn select_cache(&mut self, level: u8, ind: CsselrCacheType) {
         const CSSELR_IND_POS: u32 = 0;
         const CSSELR_IND_MASK: u32 = 1 << CSSELR_IND_POS;
         const CSSELR_LEVEL_POS: u32 = 1;
@@ -67,7 +70,7 @@ impl RegisterBlock {
     }
 
     /// Returns the number of sets and ways in the selected cache
-    pub fn cache_num_sets_ways(&self, level: u8, ind: CsselrCacheType) -> (u16, u16) {
+    pub fn cache_num_sets_ways(&mut self, level: u8, ind: CsselrCacheType) -> (u16, u16) {
         const CCSIDR_NUMSETS_POS: u32 = 13;
         const CCSIDR_NUMSETS_MASK: u32 = 0x7FFF << CCSIDR_NUMSETS_POS;
         const CCSIDR_ASSOCIATIVITY_POS: u32 = 3;

--- a/src/peripheral/dwt.rs
+++ b/src/peripheral/dwt.rs
@@ -2,6 +2,8 @@
 
 use volatile_register::{RO, RW, WO};
 
+use peripheral::DWT;
+
 /// Register block
 #[repr(C)]
 pub struct RegisterBlock {
@@ -30,13 +32,6 @@ pub struct RegisterBlock {
     pub lsr: RO<u32>,
 }
 
-impl RegisterBlock {
-    /// Enables the cycle counter
-    pub fn enable_cycle_counter(&self) {
-        unsafe { self.ctrl.modify(|r| r | 1) }
-    }
-}
-
 /// Comparator
 #[repr(C)]
 pub struct Comparator {
@@ -47,4 +42,17 @@ pub struct Comparator {
     /// Comparator Function
     pub function: RW<u32>,
     reserved: u32,
+}
+
+impl DWT {
+    /// Enables the cycle counter
+    pub fn enable_cycle_counter(&mut self) {
+        unsafe { self.ctrl.modify(|r| r | 1) }
+    }
+
+    /// Returns the current clock cycle count
+    pub fn get_cycle_count() -> u32 {
+        // NOTE(unsafe) atomic read with no side effects
+        unsafe { (*Self::ptr()).cyccnt.read() }
+    }
 }

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -7,10 +7,14 @@
 //! them at any given point in time) and the only way to get an instance of them is through the
 //! [`Peripherals::take`](struct.Peripherals.html#method.take) method.
 //!
-//! ``` ignore
+//! ``` no_run
+//! extern crate cortex_m;
+//!
+//! use cortex_m::peripheral::Peripherals;
+//!
 //! fn main() {
-//!     let peripherals = Peripherals::take();
-//!     peripherals.dwt.enable_cycle_counter();
+//!     let mut peripherals = Peripherals::take().unwrap();
+//!     peripherals.DWT.enable_cycle_counter();
 //! }
 //! ```
 //!
@@ -21,15 +25,19 @@
 //! API is provided as static methods on the peripheral types. One example is the
 //! [`DWT::cyccnt`](struct.DWT.html#method.cyccnt) method.
 //!
-//! ``` ignore
+//! ``` no_run
+//! extern crate cortex_m;
+//!
+//! use cortex_m::peripheral::{DWT, Peripherals};
+//!
 //! fn main() {
 //!     {
-//!         let peripherals = Peripherals::take().unwrap();
+//!         let mut peripherals = Peripherals::take().unwrap();
 //!         peripherals.DWT.enable_cycle_counter();
 //!     } // all the peripheral singletons are destroyed here
 //!
 //!     // but this method can be called without a DWT instance
-//!     let cyccnt = DWT::cyccnt();
+//!     let cyccnt = DWT::get_cycle_count();
 //! }
 //! ```
 //!
@@ -37,10 +45,14 @@
 //! available on all the peripheral types. This method is a useful building block for implementing
 //! higher level and safe abstractions.
 //!
-//! ``` ignore
+//! ``` no_run
+//! extern crate cortex_m;
+//!
+//! use cortex_m::peripheral::{DWT, Peripherals};
+//!
 //! fn main() {
 //!     {
-//!         let peripherals = Peripherals::take().unwrap();
+//!         let mut peripherals = Peripherals::take().unwrap();
 //!         peripherals.DWT.enable_cycle_counter();
 //!     } // all the peripheral singletons are destroyed here
 //!

--- a/src/peripheral/mod.rs
+++ b/src/peripheral/mod.rs
@@ -1,5 +1,54 @@
 //! Core peripherals
 //!
+//! # API
+//!
+//! To use (most of) the peripheral API first you must get an *instance* of the peripheral. All the
+//! core peripherals are modeled as singletons (there can only ever be, at most, one instance of
+//! them at any given point in time) and the only way to get an instance of them is through the
+//! [`Peripherals::take`](struct.Peripherals.html#method.take) method.
+//!
+//! ``` ignore
+//! fn main() {
+//!     let peripherals = Peripherals::take();
+//!     peripherals.dwt.enable_cycle_counter();
+//! }
+//! ```
+//!
+//! This method can only be successfully called *once* -- this is why the method returns an
+//! `Option`. Subsequent calls to the method will result in a `None` value being returned.
+//!
+//! A part of the peripheral API doesn't require access to a peripheral instance. This part of the
+//! API is provided as static methods on the peripheral types. One example is the
+//! [`DWT::cyccnt`](struct.DWT.html#method.cyccnt) method.
+//!
+//! ``` ignore
+//! fn main() {
+//!     {
+//!         let peripherals = Peripherals::take().unwrap();
+//!         peripherals.DWT.enable_cycle_counter();
+//!     } // all the peripheral singletons are destroyed here
+//!
+//!     // but this method can be called without a DWT instance
+//!     let cyccnt = DWT::cyccnt();
+//! }
+//! ```
+//!
+//! The singleton property can be *unsafely* bypassed using the `ptr` static method which is
+//! available on all the peripheral types. This method is a useful building block for implementing
+//! higher level and safe abstractions.
+//!
+//! ``` ignore
+//! fn main() {
+//!     {
+//!         let peripherals = Peripherals::take().unwrap();
+//!         peripherals.DWT.enable_cycle_counter();
+//!     } // all the peripheral singletons are destroyed here
+//!
+//!     // actually safe because this is an atomic read with no side effects
+//!     let cyccnt = unsafe { (*DWT::ptr()).cyccnt.read() };
+//! }
+//! ```
+//!
 //! # References
 //!
 //! - ARMv7-M Architecture Reference Manual (Issue E.b) - Chapter B3
@@ -80,7 +129,7 @@ impl Peripherals {
         })
     }
 
-    /// Unchecked version of `Peripherals::steal`
+    /// Unchecked version of `Peripherals::take`
     pub unsafe fn steal() -> Self {
         debug_assert!(!CORE_PERIPHERALS);
 
@@ -136,6 +185,12 @@ pub struct CBP {
 
 #[cfg(armv7m)]
 impl CBP {
+    pub(crate) unsafe fn new() -> Self {
+        CBP {
+            _marker: PhantomData,
+        }
+    }
+
     /// Returns a pointer to the register block
     pub fn ptr() -> *const self::cbp::RegisterBlock {
         0xE000_EF50 as *const _

--- a/src/peripheral/nvic.rs
+++ b/src/peripheral/nvic.rs
@@ -87,8 +87,8 @@ impl NVIC {
     /// Returns the NVIC priority of `interrupt`
     ///
     /// *NOTE* NVIC encodes priority in the highest bits of a byte so values like `1` and `2` map
-    /// the same priority. Also for NVIC priorities, a lower value (e.g. `16`) has higher priority
-    /// (urgency) than a larger value (e.g. `32`).
+    /// to the same priority. Also for NVIC priorities, a lower value (e.g. `16`) has higher
+    /// priority (urgency) than a larger value (e.g. `32`).
     pub fn get_priority<I>(interrupt: I) -> u8
     where
         I: Nr,

--- a/src/peripheral/nvic.rs
+++ b/src/peripheral/nvic.rs
@@ -103,7 +103,7 @@ impl NVIC {
         #[cfg(armv6m)]
         {
             // NOTE(unsafe) atomic read with no side effects
-            let ipr_n = (*Self::ptr()).ipr[Self::ipr_index(&interrupt)].read();
+            let ipr_n = unsafe { (*Self::ptr()).ipr[Self::ipr_index(&interrupt)].read() };
             let prio = (ipr_n >> Self::ipr_shift(&interrupt)) & 0x000000ff;
             prio as u8
         }

--- a/src/peripheral/test.rs
+++ b/src/peripheral/test.rs
@@ -129,7 +129,6 @@ fn scb() {
     assert_eq!(address(&scb.bfar), 0xE000_ED38);
     assert_eq!(address(&scb.afsr), 0xE000_ED3C);
     assert_eq!(address(&scb.cpacr), 0xE000_ED88);
-
 }
 
 #[test]
@@ -140,7 +139,6 @@ fn syst() {
     assert_eq!(address(&syst.rvr), 0xE000_E014);
     assert_eq!(address(&syst.cvr), 0xE000_E018);
     assert_eq!(address(&syst.calib), 0xE000_E01C);
-
 }
 
 #[test]


### PR DESCRIPTION
This PR changes the signature of many of the high level methods available on peripherals like
`NVIC::get_priority`. Additionally some instance methods have been turned into static methods. The
following guidelines have been used to apply the changes:

- If the method body contains a single, atomic read operation with *no* side effects (e.g. the read
  operation clears one of the bits of the register): the signature changed to make the method
  static, i.e. `&self` was removed from the signature.

- If the method involves writing to or a RMW operation on a register: the signature changed to take
  the singleton by `&mut self` reference.

- If the method involves only read operations where at least one of them modifies the value
  of a register: the signature changed to take the singleton by `&mut self` reference.

The rationale for this last guideline is that using `&self`, instead of `&mut self`, lets the user
(unintentionally) break abstractions in the presence of generators. Example below:

``` rust
let peripherals = Peripherals::take().unwrap();
let syst = &peripherals.SYST;

// tasks
let mut a = || {
    loop {
        // yielding "busy wait"
        while !a.has_wrapped() {
            yield;
        }

        // do stuff
    }
};

let mut b = || {
    // ..

    // *NOTE* the problem is in the line below: this `is_counter_enabled` method reads the CSR
    // register and that read operation clears the COUNTFLAG bit of the register (if set), which is
    // the bit the `has_wrapped` method checks for.
    if syst.is_counter_enabled() {
        // ..
    }

    // ..
};
```

One more guideline was considered but the required conditions didn't apply to any of the existing
methods:

- If the method involves only non side effectful, non necessarily atomic read operations: the
  signature of the method should remain as `&self`.

The rationale for this guideline is that a static method (no `self` argument) wouldn't be
appropriate because that can result in a torn read if the read operation can be preempted by some
context that modifies the register.

In any case, this last guideline doesn't seem to apply well to the peripherals structs exposed by
this crate because they *deref* to a `RegisterBlock` that allows mutation through a `&self`
reference. When these two properties (the guideline and `Deref<Target=RegisterBlock>`) are mixed
the user can potentially break abstractions using generators (as shown in the `syst` example).

cc @hannobraun
closes #67