### PR TITLE
safe `&'static mut` references through a runtime checked macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,7 @@ macro_rules! iprintln {
     };
 }
 
-/// Macro to create an statically allocated value
+/// Macro to create a mutable reference to a statically allocated value
 ///
 /// This macro returns a value with type `Option<&'static mut $ty>`. `Some($expr)` will be returned
 /// the first time the macro is executed; further calls will return `None`. To avoid `unwrap`ping a
@@ -32,10 +32,13 @@ macro_rules! iprintln {
 ///
 /// # Example
 ///
-/// ``` ignore
+/// ``` no_run
+/// #[macro_use(singleton)]
+/// extern crate cortex_m;
+///
 /// fn main() {
 ///     // OK if `main` is executed only once
-///     let x: &'static mut bool = static_!(: bool = false).unwrap();
+///     let x: &'static mut bool = singleton!(: bool = false).unwrap();
 ///
 ///     let y = alias();
 ///     // BAD this second call to `alias` will definitively `panic!`
@@ -43,11 +46,11 @@ macro_rules! iprintln {
 /// }
 ///
 /// fn alias() -> &'static mut bool {
-///     static_!(: bool = false).unwrap()
+///     singleton!(: bool = false).unwrap()
 /// }
 /// ```
 #[macro_export]
-macro_rules! static_ {
+macro_rules! singleton {
     (: $ty:ty = $expr:expr) => {
         $crate::interrupt::free(|_| unsafe {
             static mut USED: bool = false;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -22,3 +22,44 @@ macro_rules! iprintln {
         iprint!($channel, concat!($fmt, "\n"), $($arg)*);
     };
 }
+
+/// Macro to create an statically allocated value
+///
+/// This macro returns a value with type `Option<&'static mut $ty>`. `Some($expr)` will be returned
+/// the first time the macro is executed; further calls will return `None`. To avoid `unwrap`ping a
+/// `None` variant the caller must ensure that the macro is called from a function that's executed
+/// at most once in the whole lifetime of the program.
+///
+/// # Example
+///
+/// ``` ignore
+/// fn main() {
+///     // OK if `main` is executed only once
+///     let x: &'static mut bool = static_!(: bool = false).unwrap();
+///
+///     let y = alias();
+///     // BAD this second call to `alias` will definitively `panic!`
+///     let y_alias = alias();
+/// }
+///
+/// fn alias() -> &'static mut bool {
+///     static_!(: bool = false).unwrap()
+/// }
+/// ```
+#[macro_export]
+macro_rules! static_ {
+    (: $ty:ty = $expr:expr) => {
+        $crate::interrupt::free(|_| unsafe {
+            static mut USED: bool = false;
+            static mut VAR: $ty = $expr;
+
+            if USED {
+                None
+            } else {
+                USED = true;
+                let var: &'static mut _ = &mut VAR;
+                Some(var)
+            }
+        })
+    }
+}


### PR DESCRIPTION
runtime checked implementation of japaric/cortex-m-rtfm#59 that doesn't depend on RTFM macros

TODO

- [ ] bikeshed macro syntax