### PR TITLE
add a Cargo feature, cm7-r0p1, to fix a Cortex-M7 BASEPRI erratum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ script:
 
 after_script: set +e
 
-cache: cargo
+cache:
+  cargo: true
+  directories:
+    - $HOME/.xargo
 
 before_cache:
   - chmod -R a+r $HOME/.cargo;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ version = "0.3.1"
 aligned = "0.1.1"
 bare-metal = "0.1.0"
 volatile-register = "0.2.0"
+
+[features]
+cm7-r0p1 = []

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,6 +2,10 @@ set -euxo pipefail
 
 main() {
     case $TARGET in
+        thumbv7em-none-eabi*)
+            xargo check --target $TARGET --features cm7-r0p1
+            xargo check --target $TARGET
+            ;;
         thumbv*-none-eabi*)
             xargo check --target $TARGET
             ;;

--- a/src/register/basepri.rs
+++ b/src/register/basepri.rs
@@ -18,11 +18,22 @@ pub fn read() -> u8 {
 }
 
 /// Writes to the CPU register
+///
+/// **IMPORTANT** If you are using a Cortex-M7 device with revision r0p1 you MUST enable the
+/// `cm7-r0p1` Cargo feature or this function WILL misbehave.
+#[cfg_attr(not(target_arch = "arm"), allow(unused_variables))]
 #[inline]
-pub unsafe fn write(_basepri: u8) {
+pub unsafe fn write(basepri: u8) {
     match () {
         #[cfg(target_arch = "arm")]
-        () => asm!("msr BASEPRI, $0" :: "r"(_basepri) : "memory" : "volatile"),
+        () => match () {
+            #[cfg(not(feature = "cm7-r0p1"))]
+            () => asm!("msr BASEPRI, $0" :: "r"(basepri) : "memory" : "volatile"),
+            #[cfg(feature = "cm7-r0p1")]
+            () => asm!("cpsid i
+                        msr BASEPRI, $0
+                        cpsie i" :: "r"(basepri) : "memory" : "volatile"),
+        },
         #[cfg(not(target_arch = "arm"))]
         () => unimplemented!(),
     }

--- a/src/register/basepri_max.rs
+++ b/src/register/basepri_max.rs
@@ -4,12 +4,23 @@
 ///
 /// - `basepri != 0` AND `basepri::read() == 0`, OR
 /// - `basepri != 0` AND `basepri < basepri::read()`
+///
+/// **IMPORTANT** If you are using a Cortex-M7 device with revision r0p1 you MUST enable the
+/// `cm7-r0p1` Cargo feature or this function WILL misbehave.
+#[cfg_attr(not(target_arch = "arm"), allow(unused_variables))]
 #[inline]
-pub fn write(_basepri: u8) {
+pub fn write(basepri: u8) {
     match () {
         #[cfg(target_arch = "arm")]
         () => unsafe {
-            asm!("msr BASEPRI_MAX, $0" :: "r"(_basepri) : "memory" : "volatile");
+            match () {
+                #[cfg(not(feature = "cm7-r0p1"))]
+                () => asm!("msr BASEPRI_MAX, $0" :: "r"(basepri) : "memory" : "volatile"),
+                #[cfg(feature = "cm7-r0p1")]
+                () => asm!("cpsid i
+                            msr BASEPRI_MAX, $0
+                            cpsie i" :: "r"(basepri) : "memory" : "volatile"),
+            }
         },
         #[cfg(not(target_arch = "arm"))]
         () => unimplemented!(),


### PR DESCRIPTION
see japaric/cortex-m-rtfm#53 for background information