### PR TITLE
[RFC] initialize singletons at runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.4.2"
 aligned = "0.1.1"
 bare-metal = "0.1.0"
 volatile-register = "0.2.0"
+untagged-option = "0.1.1"
 
 [features]
 cm7-r0p1 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 
 extern crate aligned;
 extern crate bare_metal;
+extern crate untagged_option;
 extern crate volatile_register;
 
 #[macro_use]
@@ -31,3 +32,4 @@ pub mod peripheral;
 pub mod register;
 
 pub use peripheral::Peripherals;
+pub use untagged_option::UntaggedOption;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,13 +54,14 @@ macro_rules! singleton {
     (: $ty:ty = $expr:expr) => {
         $crate::interrupt::free(|_| unsafe {
             static mut USED: bool = false;
-            static mut VAR: $ty = $expr;
+            static mut VAR: $crate::UntaggedOption<$ty> = $crate::UntaggedOption { none: () };
 
             if USED {
                 None
             } else {
                 USED = true;
-                let var: &'static mut _ = &mut VAR;
+                VAR.some = $expr;
+                let var: &'static mut _ = &mut VAR.some;
                 Some(var)
             }
         })


### PR DESCRIPTION
This PR changes how the singletons are initialized. The advantage of initializing a singleton at
runtime is that the initial value is not constrained to only what works in const context. The
disadvantage is that this approach will use up more Flash. With the new approach, `singleton!(_:
[u8; 1024] = [0; 1024])` will invoke a memcpy at the caller site; with the old approach, the array
would have been initialized (zeroed) during startup.

The following code works with the new approach, but doesn't with the old one.

``` rust
let x = 0;
let y = singleton!(_: u32 = x);
```

cc @therealprof @hannobraun