### PR TITLE
add asm::delay

### DIFF
--- a/asm/delay.s
+++ b/asm/delay.s
@@ -1,0 +1,8 @@
+  .global __delay
+  .syntax unified
+  .thumb_func
+__delay:
+  nop
+  subs r0, #1
+  bne __delay
+  bx lr

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@ fn main() {
             .file("asm/control.s")
             .file("asm/cpsid.s")
             .file("asm/cpsie.s")
+            .file("asm/delay.s")
             .file("asm/dmb.s")
             .file("asm/dsb.s")
             .file("asm/faultmask.s")

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -24,6 +24,30 @@ pub fn bkpt() {
     }
 }
 
+/// Blocks the program for at least `n` instruction cycles
+///
+/// This is implemented in assembly so its execution time is the same regardless of the optimization
+/// level.
+///
+/// NOTE that the delay can take much longer if interrupts are serviced during its execution.
+#[inline(never)]
+pub fn delay(_n: u32) {
+    match () {
+        #[cfg(target_arch = "arm")]
+        () => unsafe {
+            asm!("1:
+                  subs $0, $$1
+                  bne.n 1b"
+                 :
+                 : "r"(_n / 3 + 1)
+                 :
+                 : "volatile");
+        },
+        #[cfg(not(target_arch = "arm"))]
+        () => unimplemented!(),
+    }
+}
+
 /// A no-operation. Useful to prevent delay loops from being optimized away.
 #[inline]
 pub fn nop() {

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -24,26 +24,37 @@ pub fn bkpt() {
     }
 }
 
-/// Blocks the program for at least `n` instruction cycles
+/// Blocks the program for *at least* `n` instruction cycles
 ///
 /// This is implemented in assembly so its execution time is the same regardless of the optimization
 /// level.
 ///
 /// NOTE that the delay can take much longer if interrupts are serviced during its execution.
-#[inline(never)]
+#[inline]
 pub fn delay(_n: u32) {
     match () {
-        #[cfg(target_arch = "arm")]
+        #[cfg(all(cortex_m, feature = "inline-asm"))]
         () => unsafe {
             asm!("1:
+                  nop
                   subs $0, $$1
                   bne.n 1b"
+                 : "+r"(_n / 4 + 1)
                  :
-                 : "r"(_n / 3 + 1)
                  :
                  : "volatile");
         },
-        #[cfg(not(target_arch = "arm"))]
+
+        #[cfg(all(cortex_m, not(feature = "inline-asm")))]
+        () => unsafe {
+            extern "C" {
+                fn __delay(n: u32);
+            }
+
+            __delay(_n / 4 + 1);
+        },
+
+        #[cfg(not(cortex_m))]
         () => unimplemented!(),
     }
 }


### PR DESCRIPTION
This PR adds an `asm::delay` function that can be used to block the program for the specified number
of instruction cycles (NB in absence of interrupts, see API docs). The implementation is done in
assembly so the execution time of that function is the same regardless of the used optimization
level.

Rationale: external devices (sensors) sometimes require delays in their initialization, or to
workaround silicon errata. Having to set up a hardware peripheral like the SysTick can be overkill
when the delay is to be done once.

Why not provide an implementation of `embedded_hal::{DelayUs, DelayMs}`? Going from instruction
cycles to human time requires knowing the clock configuration and in some cases the Flash access
latency. As all that information is device specific it's best left to device crates to implement.

Thoughts? Perhaps this is too error prone due to Flash access latency and interrupts? The interrupt
issue could be avoided by calling the asm! block within an interrupt::free call.

cc @therealprof @kunerd